### PR TITLE
Fix 401 authentication error for clearAllTransactions and exportData

### DIFF
--- a/src/PlantPassApp/src/api/transaction_interface/clearAllTransactions.ts
+++ b/src/PlantPassApp/src/api/transaction_interface/clearAllTransactions.ts
@@ -1,4 +1,4 @@
-import { API_URL } from "../config";
+import { apiRequest } from "../apiClient";
 
 interface ClearTransactionsResponse {
   message: string;
@@ -11,22 +11,7 @@ interface ClearTransactionsResponse {
  * @returns Response with the number of cleared transactions.
  */
 export async function clearAllTransactions(): Promise<ClearTransactionsResponse> {
-  try {
-    const response = await fetch(`${API_URL}/transactions/clear-all`, {
-      method: "DELETE",
-      headers: { "Content-Type": "application/json" },
-    });
-
-    if (!response.ok) {
-      const errorBody = await response.json().catch(() => ({})) as { message?: string };
-      throw new Error(
-        `HTTP ${response.status}: ${errorBody.message || "Unknown error"}`,
-      );
-    }
-
-    const result = await response.json() as ClearTransactionsResponse;
-    return result;
-  } catch (err) {
-    throw err;
-  }
+  return apiRequest<ClearTransactionsResponse>('/transactions/clear-all', {
+    method: 'DELETE'
+  });
 }

--- a/src/PlantPassApp/src/api/transaction_interface/exportData.ts
+++ b/src/PlantPassApp/src/api/transaction_interface/exportData.ts
@@ -1,4 +1,4 @@
-import { API_URL } from '../config';
+import { apiRequest } from '../apiClient';
 
 interface ExportDataResponse {
   filename: string;
@@ -11,13 +11,10 @@ interface ExportDataResponse {
  * @returns Object with filename, content (base64), and content_type
  */
 export const exportData = async (): Promise<ExportDataResponse> => {
-  const response = await fetch(`${API_URL}/transactions/export-data`);
+  const data = await apiRequest<{ filename: string; content: string; content_type: string }>(
+    '/transactions/export-data'
+  );
   
-  if (!response.ok) {
-    throw new Error('Export failed');
-  }
-  
-  const data = await response.json() as { filename: string; content: string; content_type: string };
   return {
     filename: data.filename,
     content: data.content,


### PR DESCRIPTION
- Replace direct fetch calls with apiRequest from apiClient
- Ensures Authorization Bearer token is included in requests
- Aligns with authentication pattern used by other API endpoints
- Fixes DELETE /transactions/clear-all 401 Unauthorized error